### PR TITLE
Expose insertSpans utility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import Date from "@root/date";
 import RichText from "@root/richtext";
 import Link from "@root/link";
+import { insertSpans } from '@utils/spans';
 
-module.exports = { Date, RichText, Link };
+module.exports = { Date, RichText, Link, insertSpans };


### PR DESCRIPTION
The `insertSpans` utility is extremely helpful and should be exposed. That would also help my situation, in which I'm taking care of rendering the blocks, but don't need to handle the rendering of inline elements.