### PR TITLE
Fix content null case

### DIFF
--- a/src/richtext.js
+++ b/src/richtext.js
@@ -66,7 +66,7 @@ function serializeLabel(element, children) {
 }
 
 function serializeSpan(content) {
-  return content.replace(/\n/g, "<br />");
+  return content ? content.replace(/\n/g, "<br />") : "";
 }
 
 export default {


### PR DESCRIPTION
```
TypeError: Cannot read property 'replace' of null
```
I had this error if content of span is empty.