### PR TITLE
Small fixes

### DIFF
--- a/src/richtext.js
+++ b/src/richtext.js
@@ -49,7 +49,7 @@ function serializeEmbed(element) {
   return (`
     <div data-oembed="${element.embed_url}"
       data-oembed-type="${element.type}"
-      data-oembed-provider="${element.provider_name}
+      data-oembed-provider="${element.provider_name}"
       ${label(element)}>
           
       ${element.oembed.html}

--- a/src/richtext.js
+++ b/src/richtext.js
@@ -66,7 +66,7 @@ function serializeLabel(element, children) {
 }
 
 function serializeSpan(content) {
-  return content.replace(/\n/g, "<br />");
+  return content ? content.replace(/\n/g, "<br />") : '';
 }
 
 export default {


### PR DESCRIPTION
Two Fixes for Prismic DOM:

 1. There was a crash when serializing empty spans, prismic-richtext provides `null` for empty strings, but prismic-dom expected a string. (The null specified in the prismic-richtext typings, so i fixed it here)
 
 2. There was an unclosed string in the embedded objects serializing template.