### PR TITLE
Update richtext.js

### DIFF
--- a/src/richtext.js
+++ b/src/richtext.js
@@ -48,7 +48,7 @@ function serializeImage(linkResolver, element) {
   const img = `<img src="${element.url}" alt="${element.alt || ''}" copyright="${element.copyright || ''}">`;
   
   return (`
-    <p class="${wrapperClassList.join(' ')}">
+    <p class="${wrapperClassList.join('')}">
       ${linkUrl ? `<a ${linkTarget} href="${linkUrl}">${img}</a>` : img}
     </p>
   `);


### PR DESCRIPTION
An extra space here prevents the wrapperClassList from being `block-img`. It gets inserted into the DOM as below
<img width="534" alt="Screen Shot 2021-02-04 at 12 52 01 PM" src="https://user-images.githubusercontent.com/68235993/106947620-39a17980-66f0-11eb-9ed9-85a083c50bce.png">
